### PR TITLE
Update audio_norm.sh

### DIFF
--- a/audio_norm.sh
+++ b/audio_norm.sh
@@ -20,9 +20,9 @@ logAddToLine "Complete! Max volume is: ${maxVolume} dB"
 volumeBoost="${maxVolume:1}"
 audioCodec=$(ffprobe "${1}" 2>&1 >/dev/null |grep Stream.*Audio | sed -e 's/.*Audio: //' -e 's/[, ].*//')
 
-if [[ -z "${format+x}" ]]; then #if the variable $format is unassigned, then run ffmpeg command w/out -c:v copy, otherwise include it
-	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
-else
+if [ $format="Video" ]; then #if the variable $format is "Video", then run ffmpeg command with -c:v copy, otherwise omit it
 	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:v copy -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
+else
+	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
 fi
 

--- a/audio_norm.sh
+++ b/audio_norm.sh
@@ -20,4 +20,9 @@ logAddToLine "Complete! Max volume is: ${maxVolume} dB"
 volumeBoost="${maxVolume:1}"
 audioCodec=$(ffprobe "${1}" 2>&1 >/dev/null |grep Stream.*Audio | sed -e 's/.*Audio: //' -e 's/[, ].*//')
 
-logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:v copy -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
+if [[ -z "${format+x}" ]]; then #if the variable $format is unassigned, then run ffmpeg command w/out -c:v copy, otherwise include it
+	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
+else
+	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:v copy -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
+fi
+

--- a/audio_norm.sh
+++ b/audio_norm.sh
@@ -20,7 +20,7 @@ logAddToLine "Complete! Max volume is: ${maxVolume} dB"
 volumeBoost="${maxVolume:1}"
 audioCodec=$(ffprobe "${1}" 2>&1 >/dev/null |grep Stream.*Audio | sed -e 's/.*Audio: //' -e 's/[, ].*//')
 
-if [ $format="Video" ]; then #if the variable $format is "Video", then run ffmpeg command with -c:v copy, otherwise omit it
+if [[ $format = "Video" ]] ; then #if the variable $format is "Video", then run ffmpeg command with -c:v copy, otherwise omit it
 	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:v copy -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"
 else
 	logLog ffmpeg -hide_banner -loglevel error -i "${1}" -af "volume="${volumeBoost}"dB" -c:a ${audioCodec} -y "${1%.*}_normalized.${extension}"


### PR DESCRIPTION
Example of how the $format variable could be used for video specific commands. This if statement simply omits the -c:v flag from the ffmpeg command if $format is not video